### PR TITLE
Replace variables called 'async' with Python 3.7 friendly 'async_'

### DIFF
--- a/pytest_ngsfixtures/shell.py
+++ b/pytest_ngsfixtures/shell.py
@@ -48,7 +48,7 @@ class shell:
       image (Image): docker/singularity image to run in
       iterable (bool): return output as iterable
       read (bool): read and return output
-      async (bool): run asynchronously
+      async_ (bool): run asynchronously
       path_list (list): prefix command with additional paths
       stdout (_io.TextIOWrapper, int): stdout file object
       stderr (int): stderr special value
@@ -84,11 +84,11 @@ class shell:
                 image=None,
                 iterable=False,
                 read=False,
-                async=False,
+                async_=False,
                 path_list=[],
                 **kwargs):
 
-        stdout = sp.PIPE if iterable or async or read else kwargs.pop("stdout", STDOUT)
+        stdout = sp.PIPE if iterable or async_ or read else kwargs.pop("stdout", STDOUT)
         stderr = kwargs.pop("stderr", STDOUT)
 
         close_fds = sys.platform != 'win32'
@@ -96,7 +96,7 @@ class shell:
         if kwargs.get("stream", False):
             iterable = kwargs.pop("stream")
         if kwargs.get("detach", False):
-            async = kwargs.pop("detach")
+            async_ = kwargs.pop("detach")
 
         if conda_env_list:
             if not conda_root:
@@ -129,9 +129,9 @@ class shell:
         if container:
             try:
                 proc = container.exec_run(cmd, stream=iterable,
-                                          detach=async,
+                                          detach=async_,
                                           **kwargs)
-                if async:
+                if async_:
                     proc = proc.output
             except:
                 raise
@@ -139,7 +139,7 @@ class shell:
             try:
                 client = docker.from_env()
                 proc = client.containers.run(image, command=cmd,
-                                             detach=async,
+                                             detach=async_,
                                              **kwargs)
             except:
                 raise
@@ -156,7 +156,7 @@ class shell:
         if read:
             proc = cls.read_stdout(proc)
             return cls.stdout(proc, cmd, ret=proc)
-        elif async:
+        elif async_:
             return proc
 
         return cls.stdout(proc, cmd)

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -38,7 +38,7 @@ def test_shell_read(foo):
 
 
 def test_shell_async(foo):
-    ret = shell("ls " + str(foo), async=True)
+    ret = shell("ls " + str(foo), async_=True)
     assert isinstance(ret, sp.Popen)
 
 


### PR DESCRIPTION
Starting with Python 3.7, `async` (and `await`) have become reserved keywords ([source](https://docs.python.org/3/whatsnew/3.7.html)). As a consequence, any code using `async` as a variable name will break.

This PR fixes this by replacing all variables called `async` with `async_`.